### PR TITLE
Properly credit the image

### DIFF
--- a/content/blog/face_detection_with_tensorflow_rust.md
+++ b/content/blog/face_detection_with_tensorflow_rust.md
@@ -18,7 +18,7 @@ We will be using a pre-trained model called [mtcnn](https://kpzhang93.github.io/
 
 We want to read the photo, have the faces detected, and then return an image with the bounding boxes drawn in.
 
-In other words, we want to convert this (Image courtesy of the [rust community](https://www.rust-lang.org/community) page):
+In other words, we want to convert this (Image used with permission of [RustFest](https://rustfest.eu), taken by [Fiona Castiñeira](https://fionacastineira.com/)):
 
 [![](/photos/rustfest.jpg)](/photos/rustfest.jpg)
 


### PR DESCRIPTION
Hi,

thanks for your blog post on Tensorflow image detection.

The image you use is actually not free for modification or use, the Rust website only has permission. The rightsholder is RustFest, which I organise, and its photographer.

We have no issue with liberal use, though, so here's a pull request fixing the attribution :).

Best,
Florian