### PR TITLE
Fix typo and add alternative

### DIFF
--- a/content/blog/face_detection_with_actix_web.md
+++ b/content/blog/face_detection_with_actix_web.md
@@ -789,6 +789,10 @@ fn return_overlay(
                 .headers_mut()
                 .insert(CONTENT_TYPE, HeaderValue::from_static("image/jpeg"));
             response
+            // alternatively, use the builder pattern for response
+            // HttpResponse::Ok()
+            //     .content_type("image/jpeg")
+            //     .message(body.into())
         })
 }
 ```
@@ -811,7 +815,7 @@ HttpServer::new(move || {
 Great! Let's run it:
 
 ```
-$ curl --data-binary @rustfest.jpg  http://localhost:8000/api/v1/bboxes > output.jpg
+$ curl --data-binary @rustfest.jpg  http://localhost:8000/api/v1/overlay > output.jpg
 ```
 
 And we have our original overlay!


### PR DESCRIPTION
By the way, I think it would be better to include the imports so that others does not need to go to check out what to import.

As well, I wonder why we could not just borrow `DynamicImage` or `get_image`?

```rust
fn get_image(stream: web::Payload) -> impl Future<Item = DynamicImage, Error = ActixError> {
    stream
        .concat2()
        .from_err()
        .and_then(move |bytes| web::block(move || image::load_from_memory(&bytes)).from_err())
}
```

I tried just borrow but it requires it to be static.